### PR TITLE
Removed bower.json, .bowerrc, and removed ember-data from package.json

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,4 +1,0 @@
-{
-  "directory": "bower_components",
-  "analytics": false
-}

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,4 @@ before_install:
   - "npm install -g npm@^2"
 
 install:
-  - npm install -g bower
   - npm install
-  - bower install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,6 @@ install:
 
 cache:
   - '%APPDATA%\npm-cache'
-  - '%APPDATA%\Roaming\bower'
 
 # Post-install test scripts.
 test_script:

--- a/bower.json
+++ b/bower.json
@@ -1,9 +1,0 @@
-{
-  "name": "ember-cli-legacy-blueprints",
-  "dependencies": {
-    "ember": "~2.4.1",
-    "ember-cli-shims": "0.1.0",
-    "ember-cli-test-loader": "0.2.2",
-    "ember-qunit-notifications": "0.1.0"
-  }
-}

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "ember-cli-release": "0.2.8",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "emberjs/data#95d05cf",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",


### PR DESCRIPTION
No longer need `bower.json` or `.bowerrc` as we're not testing a project. Removed `ember-data` as a devDep, as I think it would actually override the blueprints in ember-cli-legacy-blueprints, as the ember-data package has priority.