### PR TITLE
Fix addon initialization order

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",
-    "after": [
+    "before": [
       "ember-core",
       "ember-data"
     ]


### PR DESCRIPTION
This addon should be initialized *before* the core addons so that the core addons can overwrite the blueprints from this project.

see https://github.com/ember-cli/ember-cli/issues/5868

/cc @trabus @rwjblue @stefanpenner 