### PR TITLE
Remove space from blank line for component unit-tests

### DIFF
--- a/blueprints/component-test/qunit-files/tests/__testType__/__path__/__test__.js
+++ b/blueprints/component-test/qunit-files/tests/__testType__/__path__/__test__.js
@@ -8,7 +8,7 @@ moduleForComponent('<%= componentPathName %>', '<%= friendlyTestDescription %>',
 });
 
 test('it renders', function(assert) {
-  <% if (testType === 'integration' ) { %>// Set any properties with this.set('myProperty', 'value');
+<% if (testType === 'integration' ) { %>// Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
 
   this.render(hbs`{{<%= componentPathName %>}}`);

--- a/blueprints/component-test/qunit-files/tests/__testType__/__path__/__test__.js
+++ b/blueprints/component-test/qunit-files/tests/__testType__/__path__/__test__.js
@@ -8,7 +8,8 @@ moduleForComponent('<%= componentPathName %>', '<%= friendlyTestDescription %>',
 });
 
 test('it renders', function(assert) {
-<% if (testType === 'integration' ) { %>// Set any properties with this.set('myProperty', 'value');
+<% if (testType === 'integration' ) { %>
+  // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
 
   this.render(hbs`{{<%= componentPathName %>}}`);


### PR DESCRIPTION
When generating a unit-test for a component, a blank line with a space is generated, which causes lint to fail. Related ember PR: https://github.com/emberjs/ember.js/pull/14504.