### PR TITLE
Refactor blueprints to eliminate directly accessing Ember properties

### DIFF
--- a/blueprints/acceptance-test/mocha-files/tests/acceptance/__name__-test.js
+++ b/blueprints/acceptance-test/mocha-files/tests/acceptance/__name__-test.js
@@ -2,6 +2,7 @@ import { describe, it, beforeEach, afterEach } from 'mocha';
 import { expect } from 'chai';
 import startApp from '../helpers/start-app';
 <% if (destroyAppExists) { %>import destroyApp from '../helpers/destroy-app';<% } else { %>import Ember from 'ember';<% } %>
+<% if (!destroyAppExists) { %>const { Application, run } = Ember;<% } %>
 
 describe('<%= friendlyTestName %>', function() {
   let application;
@@ -11,7 +12,7 @@ describe('<%= friendlyTestName %>', function() {
   });
 
   afterEach(function() {
-    <% if (destroyAppExists) { %>destroyApp(application);<% } else { %>Ember.run(application, 'destroy');<% } %>
+    <% if (destroyAppExists) { %>destroyApp(application);<% } else { %>run(application, 'destroy');<% } %>
   });
 
   it('can visit /<%= dasherizedModuleName %>', function() {

--- a/blueprints/component/files/__root__/__path__/__name__.js
+++ b/blueprints/component/files/__root__/__path__/__name__.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+const { Component } = Ember;
 <%= importTemplate %>
-export default Ember.Component.extend({<%= contents %>
+export default Component.extend({<%= contents %>
 });

--- a/blueprints/controller/files/__root__/__path__/__name__.js
+++ b/blueprints/controller/files/__root__/__path__/__name__.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+const { Controller } = Ember;
 
-export default Ember.Controller.extend({
+export default Controller.extend({
 });

--- a/blueprints/helper/files/__root__/helpers/__name__.js
+++ b/blueprints/helper/files/__root__/helpers/__name__.js
@@ -1,7 +1,8 @@
 import Ember from 'ember';
+const { Helper } = Ember;
 
 export function <%= camelizedModuleName %>(params/*, hash*/) {
   return params;
 }
 
-export default Ember.Helper.helper(<%= camelizedModuleName %>);
+export default Helper.helper(<%= camelizedModuleName %>);

--- a/blueprints/initializer-test/mocha-files/tests/unit/initializers/__name__-test.js
+++ b/blueprints/initializer-test/mocha-files/tests/unit/initializers/__name__-test.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { describe, it, beforeEach } from 'mocha';
 import Ember from 'ember';
+const { Application, run } = Ember;
 import { initialize } from '<%= dasherizedModulePrefix %>/initializers/<%= dasherizedModuleName %>';
 import destroyApp from '../../helpers/destroy-app';
 
@@ -8,8 +9,8 @@ describe('<%= friendlyTestName %>', function() {
   let application;
 
   beforeEach(function() {
-    Ember.run(function() {
-      application = Ember.Application.create();
+    run(function() {
+      application = Application.create();
       application.deferReadiness();
     });
   });

--- a/blueprints/initializer-test/qunit-files/tests/unit/initializers/__name__-test.js
+++ b/blueprints/initializer-test/qunit-files/tests/unit/initializers/__name__-test.js
@@ -1,12 +1,13 @@
 import Ember from 'ember';
+const { Application, run } = Ember;
 import { initialize } from '<%= dasherizedModulePrefix %>/initializers/<%= dasherizedModuleName %>';
 import { module, test } from 'qunit';
 import destroyApp from '../../helpers/destroy-app';
 
 module('<%= friendlyTestName %>', {
   beforeEach() {
-    Ember.run(() => {
-      this.application = Ember.Application.create();
+    run(() => {
+      this.application = Application.create();
       this.application.deferReadiness();
     });
   },

--- a/blueprints/instance-initializer-test/mocha-files/tests/unit/instance-initializers/__name__-test.js
+++ b/blueprints/instance-initializer-test/mocha-files/tests/unit/instance-initializers/__name__-test.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { describe, it, beforeEach } from 'mocha';
 import Ember from 'ember';
+const { Application, run } = Ember;
 import { initialize } from '<%= dasherizedModulePrefix %>/instance-initializers/<%= dasherizedModuleName %>';
 import destroyApp from '../../helpers/destroy-app';
 
@@ -8,14 +9,14 @@ describe('<%= friendlyTestName %>', function() {
   let application, appInstance;
 
   beforeEach(function() {
-    Ember.run(function() {
-      application = Ember.Application.create();
+    run(function() {
+      application = Application.create();
       appInstance = application.buildInstance();
     });
   });
 
   afterEach(function() {
-    Ember.run(appInstance, 'destroy');
+    run(appInstance, 'destroy');
     destroyApp(application);
   });
 

--- a/blueprints/instance-initializer-test/qunit-files/tests/unit/instance-initializers/__name__-test.js
+++ b/blueprints/instance-initializer-test/qunit-files/tests/unit/instance-initializers/__name__-test.js
@@ -1,17 +1,18 @@
 import Ember from 'ember';
+const { Application, run } = Ember;
 import { initialize } from '<%= dasherizedModulePrefix %>/instance-initializers/<%= dasherizedModuleName %>';
 import { module, test } from 'qunit';
 import destroyApp from '../../helpers/destroy-app';
 
 module('<%= friendlyTestName %>', {
   beforeEach() {
-    Ember.run(() => {
-      this.application = Ember.Application.create();
+    run(() => {
+      this.application = Application.create();
       this.appInstance = this.application.buildInstance();
     });
   },
   afterEach() {
-    Ember.run(this.appInstance, 'destroy');
+    run(this.appInstance, 'destroy');
     destroyApp(this.application);
   }
 });

--- a/blueprints/mixin-test/mocha-files/tests/unit/mixins/__name__-test.js
+++ b/blueprints/mixin-test/mocha-files/tests/unit/mixins/__name__-test.js
@@ -1,12 +1,13 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import Ember from 'ember';
+const { Object } = Ember;
 import <%= classifiedModuleName %>Mixin from '<%= dasherizedPackageName %>/mixins/<%= dasherizedModuleName %>';
 
 describe('<%= friendlyTestName %>', function() {
   // Replace this with your real tests.
   it('works', function() {
-    let <%= classifiedModuleName %>Object = Ember.Object.extend(<%= classifiedModuleName %>Mixin);
+    let <%= classifiedModuleName %>Object = Object.extend(<%= classifiedModuleName %>Mixin);
     let subject = <%= classifiedModuleName %>Object.create();
     expect(subject).to.be.ok;
   });

--- a/blueprints/mixin-test/qunit-files/tests/unit/mixins/__name__-test.js
+++ b/blueprints/mixin-test/qunit-files/tests/unit/mixins/__name__-test.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+const { Object } = Ember;
 import <%= classifiedModuleName %>Mixin from '<%= projectName %>/mixins/<%= dasherizedModuleName %>';
 import { module, test } from 'qunit';
 
@@ -6,7 +7,7 @@ module('<%= friendlyTestName %>');
 
 // Replace this with your real tests.
 test('it works', function(assert) {
-  let <%= classifiedModuleName %>Object = Ember.Object.extend(<%= classifiedModuleName %>Mixin);
+  let <%= classifiedModuleName %>Object = Object.extend(<%= classifiedModuleName %>Mixin);
   let subject = <%= classifiedModuleName %>Object.create();
   assert.ok(subject);
 });

--- a/blueprints/mixin/files/__root__/mixins/__name__.js
+++ b/blueprints/mixin/files/__root__/mixins/__name__.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+const { Mixin } = Ember;
 
-export default Ember.Mixin.create({
+export default Mixin.create({
 });

--- a/blueprints/route/files/__root__/__path__/__name__.js
+++ b/blueprints/route/files/__root__/__path__/__name__.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+const { Route } = Ember;
 
-export default Ember.Route.extend({
+export default Route.extend({
 });

--- a/blueprints/service/files/__root__/__path__/__name__.js
+++ b/blueprints/service/files/__root__/__path__/__name__.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+const { Service } = Ember;
 
-export default Ember.Service.extend({
+export default Service.extend({
 });

--- a/blueprints/test-helper/files/tests/helpers/__name__.js
+++ b/blueprints/test-helper/files/tests/helpers/__name__.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
+const { Test } = Ember;
 
-export default Ember.Test.registerAsyncHelper('<%= camelizedModuleName %>', function(app) {
+export default Test.registerAsyncHelper('<%= camelizedModuleName %>', function(app) {
 
 });

--- a/blueprints/view/files/__root__/__path__/__name__.js
+++ b/blueprints/view/files/__root__/__path__/__name__.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+const { View } = Ember;
 
-export default Ember.View.extend({
+export default View.extend({
 });

--- a/node-tests/blueprints/component-test.js
+++ b/node-tests/blueprints/component-test.js
@@ -22,7 +22,7 @@ describe('Acceptance: ember generate component', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/components/x-foo.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain("export default Ember.Component.extend({")
+          .to.contain("export default Component.extend({")
           .to.contain("});");
 
         expect(_file('app/templates/components/x-foo.hbs'))
@@ -45,7 +45,7 @@ describe('Acceptance: ember generate component', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/components/foo/x-foo.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain("export default Ember.Component.extend({")
+          .to.contain("export default Component.extend({")
           .to.contain("});");
 
         expect(_file('app/templates/components/foo/x-foo.hbs'))
@@ -68,7 +68,7 @@ describe('Acceptance: ember generate component', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/components/x-foo.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain("export default Ember.Component.extend({")
+          .to.contain("export default Component.extend({")
           .to.contain("});");
 
         expect(_file('app/templates/components/x-foo.hbs'))
@@ -92,7 +92,7 @@ describe('Acceptance: ember generate component', function() {
         expect(_file('addon/components/x-foo.js'))
           .to.contain("import Ember from 'ember';")
           .to.contain("import layout from '../templates/components/x-foo';")
-          .to.contain("export default Ember.Component.extend({")
+          .to.contain("export default Component.extend({")
           .to.contain("layout")
           .to.contain("});");
 
@@ -120,7 +120,7 @@ describe('Acceptance: ember generate component', function() {
         expect(_file('addon/components/nested/x-foo.js'))
           .to.contain("import Ember from 'ember';")
           .to.contain("import layout from '../../templates/components/nested/x-foo';")
-          .to.contain("export default Ember.Component.extend({")
+          .to.contain("export default Component.extend({")
           .to.contain("layout")
           .to.contain("});");
 
@@ -147,7 +147,7 @@ describe('Acceptance: ember generate component', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('tests/dummy/app/components/x-foo.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain("export default Ember.Component.extend({")
+          .to.contain("export default Component.extend({")
           .to.contain("});");
 
         expect(_file('tests/dummy/app/templates/components/x-foo.hbs'))
@@ -168,7 +168,7 @@ describe('Acceptance: ember generate component', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('tests/dummy/app/components/nested/x-foo.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain("export default Ember.Component.extend({")
+          .to.contain("export default Component.extend({")
           .to.contain("});");
 
         expect(_file('tests/dummy/app/templates/components/nested/x-foo.hbs'))
@@ -190,7 +190,7 @@ describe('Acceptance: ember generate component', function() {
         expect(_file('lib/my-addon/addon/components/x-foo.js'))
           .to.contain("import Ember from 'ember';")
           .to.contain("import layout from '../templates/components/x-foo';")
-          .to.contain("export default Ember.Component.extend({")
+          .to.contain("export default Component.extend({")
           .to.contain("layout")
           .to.contain("});");
 
@@ -245,7 +245,7 @@ describe('Acceptance: ember generate component', function() {
         expect(_file('lib/my-addon/addon/components/nested/x-foo.js'))
           .to.contain("import Ember from 'ember';")
           .to.contain("import layout from '../../templates/components/nested/x-foo';")
-          .to.contain("export default Ember.Component.extend({")
+          .to.contain("export default Component.extend({")
           .to.contain("layout")
           .to.contain("});");
 
@@ -273,7 +273,7 @@ describe('Acceptance: ember generate component', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/components/x-foo/component.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain("export default Ember.Component.extend({")
+          .to.contain("export default Component.extend({")
           .to.contain("});");
 
         expect(_file('app/components/x-foo/template.hbs'))
@@ -295,7 +295,7 @@ describe('Acceptance: ember generate component', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/pods/components/x-foo/component.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain("export default Ember.Component.extend({")
+          .to.contain("export default Component.extend({")
           .to.contain("});");
 
         expect(_file('app/pods/components/x-foo/template.hbs'))
@@ -318,7 +318,7 @@ describe('Acceptance: ember generate component', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/components/foo/x-foo/component.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain("export default Ember.Component.extend({")
+          .to.contain("export default Component.extend({")
           .to.contain("});");
 
         expect(_file('app/components/foo/x-foo/template.hbs'))
@@ -342,7 +342,7 @@ describe('Acceptance: ember generate component', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/pods/components/foo/x-foo/component.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain("export default Ember.Component.extend({")
+          .to.contain("export default Component.extend({")
           .to.contain("});");
 
         expect(_file('app/pods/components/foo/x-foo/template.hbs'))
@@ -365,7 +365,7 @@ describe('Acceptance: ember generate component', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/bar/x-foo/component.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain("export default Ember.Component.extend({")
+          .to.contain("export default Component.extend({")
           .to.contain("});");
 
         expect(_file('app/bar/x-foo/template.hbs'))
@@ -389,7 +389,7 @@ describe('Acceptance: ember generate component', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/pods/bar/x-foo/component.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain("export default Ember.Component.extend({")
+          .to.contain("export default Component.extend({")
           .to.contain("});");
 
         expect(_file('app/pods/bar/x-foo/template.hbs'))
@@ -412,7 +412,7 @@ describe('Acceptance: ember generate component', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/bar/foo/x-foo/component.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain("export default Ember.Component.extend({")
+          .to.contain("export default Component.extend({")
           .to.contain("});");
 
         expect(_file('app/bar/foo/x-foo/template.hbs'))
@@ -436,7 +436,7 @@ describe('Acceptance: ember generate component', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/pods/bar/foo/x-foo/component.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain("export default Ember.Component.extend({")
+          .to.contain("export default Component.extend({")
           .to.contain("});");
 
         expect(_file('app/pods/bar/foo/x-foo/template.hbs'))
@@ -458,7 +458,7 @@ describe('Acceptance: ember generate component', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/bar/baz/x-foo/component.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain("export default Ember.Component.extend({")
+          .to.contain("export default Component.extend({")
           .to.contain("});");
 
         expect(_file('app/bar/baz/x-foo/template.hbs'))
@@ -482,7 +482,7 @@ describe('Acceptance: ember generate component', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/pods/bar/baz/x-foo/component.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain("export default Ember.Component.extend({")
+          .to.contain("export default Component.extend({")
           .to.contain("});");
 
         expect(_file('app/pods/bar/baz/x-foo/template.hbs'))
@@ -505,7 +505,7 @@ describe('Acceptance: ember generate component', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/bar/baz/foo/x-foo/component.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain("export default Ember.Component.extend({")
+          .to.contain("export default Component.extend({")
           .to.contain("});");
 
         expect(_file('app/bar/baz/foo/x-foo/template.hbs'))
@@ -529,7 +529,7 @@ describe('Acceptance: ember generate component', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/pods/bar/baz/foo/x-foo/component.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain("export default Ember.Component.extend({")
+          .to.contain("export default Component.extend({")
           .to.contain("});");
 
         expect(_file('app/pods/bar/baz/foo/x-foo/template.hbs'))
@@ -552,7 +552,7 @@ describe('Acceptance: ember generate component', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/x-foo/component.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain("export default Ember.Component.extend({")
+          .to.contain("export default Component.extend({")
           .to.contain("});");
 
         expect(_file('app/x-foo/template.hbs'))
@@ -576,7 +576,7 @@ describe('Acceptance: ember generate component', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/pods/x-foo/component.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain("export default Ember.Component.extend({")
+          .to.contain("export default Component.extend({")
           .to.contain("});");
 
         expect(_file('app/pods/x-foo/template.hbs'))
@@ -599,7 +599,7 @@ describe('Acceptance: ember generate component', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/foo/x-foo/component.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain("export default Ember.Component.extend({")
+          .to.contain("export default Component.extend({")
           .to.contain("});");
 
         expect(_file('app/foo/x-foo/template.hbs'))
@@ -623,7 +623,7 @@ describe('Acceptance: ember generate component', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/pods/foo/x-foo/component.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain("export default Ember.Component.extend({")
+          .to.contain("export default Component.extend({")
           .to.contain("});");
 
         expect(_file('app/pods/foo/x-foo/template.hbs'))
@@ -644,7 +644,7 @@ describe('Acceptance: ember generate component', function() {
         expect(_file('addon/components/x-foo/component.js'))
           .to.contain("import Ember from 'ember';")
           .to.contain("import layout from './template';")
-          .to.contain("export default Ember.Component.extend({")
+          .to.contain("export default Component.extend({")
           .to.contain("layout")
           .to.contain("});");
 
@@ -669,7 +669,7 @@ describe('Acceptance: ember generate component', function() {
         expect(_file('lib/my-addon/addon/components/x-foo/component.js'))
           .to.contain("import Ember from 'ember';")
           .to.contain("import layout from './template';")
-          .to.contain("export default Ember.Component.extend({")
+          .to.contain("export default Component.extend({")
           .to.contain("layout")
           .to.contain("});");
 
@@ -694,7 +694,7 @@ describe('Acceptance: ember generate component', function() {
         expect(_file('lib/my-addon/addon/components/nested/x-foo/component.js'))
           .to.contain("import Ember from 'ember';")
           .to.contain("import layout from './template';")
-          .to.contain("export default Ember.Component.extend({")
+          .to.contain("export default Component.extend({")
           .to.contain("layout")
           .to.contain("});");
 

--- a/node-tests/blueprints/controller-test.js
+++ b/node-tests/blueprints/controller-test.js
@@ -22,7 +22,7 @@ describe('Acceptance: ember generate and destroy controller', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/controllers/foo.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain("export default Ember.Controller.extend({\n});");
+          .to.contain("export default Controller.extend({\n});");
 
         expect(_file('tests/unit/controllers/foo-test.js'))
           .to.contain("import { moduleFor, test } from 'ember-qunit';")
@@ -37,7 +37,7 @@ describe('Acceptance: ember generate and destroy controller', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/controllers/foo/bar.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain("export default Ember.Controller.extend({\n});");
+          .to.contain("export default Controller.extend({\n});");
 
         expect(_file('tests/unit/controllers/foo/bar-test.js'))
           .to.contain("import { moduleFor, test } from 'ember-qunit';")
@@ -52,7 +52,7 @@ describe('Acceptance: ember generate and destroy controller', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('addon/controllers/foo.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain("export default Ember.Controller.extend({\n});");
+          .to.contain("export default Controller.extend({\n});");
 
         expect(_file('app/controllers/foo.js'))
           .to.contain("export { default } from 'my-addon/controllers/foo';");
@@ -70,7 +70,7 @@ describe('Acceptance: ember generate and destroy controller', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('addon/controllers/foo/bar.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain("export default Ember.Controller.extend({\n});");
+          .to.contain("export default Controller.extend({\n});");
 
         expect(_file('app/controllers/foo/bar.js'))
           .to.contain("export { default } from 'my-addon/controllers/foo/bar';");
@@ -88,7 +88,7 @@ describe('Acceptance: ember generate and destroy controller', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('tests/dummy/app/controllers/foo.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain("export default Ember.Controller.extend({\n});");
+          .to.contain("export default Controller.extend({\n});");
 
         expect(_file('app/controllers/foo-test.js'))
           .to.not.exist;
@@ -104,7 +104,7 @@ describe('Acceptance: ember generate and destroy controller', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('tests/dummy/app/controllers/foo/bar.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain("export default Ember.Controller.extend({\n});");
+          .to.contain("export default Controller.extend({\n});");
 
         expect(_file('app/controllers/foo/bar.js'))
           .to.not.exist;
@@ -120,7 +120,7 @@ describe('Acceptance: ember generate and destroy controller', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('lib/my-addon/addon/controllers/foo.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain("export default Ember.Controller.extend({\n});");
+          .to.contain("export default Controller.extend({\n});");
 
         expect(_file('lib/my-addon/app/controllers/foo.js'))
           .to.contain("export { default } from 'my-addon/controllers/foo';");
@@ -138,7 +138,7 @@ describe('Acceptance: ember generate and destroy controller', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('lib/my-addon/addon/controllers/foo/bar.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain("export default Ember.Controller.extend({\n});");
+          .to.contain("export default Controller.extend({\n});");
 
         expect(_file('lib/my-addon/app/controllers/foo/bar.js'))
           .to.contain("export { default } from 'my-addon/controllers/foo/bar';");
@@ -156,7 +156,7 @@ describe('Acceptance: ember generate and destroy controller', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/foo/controller.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain("export default Ember.Controller.extend({\n});");
+          .to.contain("export default Controller.extend({\n});");
 
         expect(_file('tests/unit/foo/controller-test.js'))
           .to.contain("import { moduleFor, test } from 'ember-qunit';")
@@ -172,7 +172,7 @@ describe('Acceptance: ember generate and destroy controller', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/pods/foo/controller.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain("export default Ember.Controller.extend({\n});");
+          .to.contain("export default Controller.extend({\n});");
 
         expect(_file('tests/unit/pods/foo/controller-test.js'))
           .to.contain("import { moduleFor, test } from 'ember-qunit';")
@@ -187,7 +187,7 @@ describe('Acceptance: ember generate and destroy controller', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/foo/bar/controller.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain("export default Ember.Controller.extend({\n});");
+          .to.contain("export default Controller.extend({\n});");
 
         expect(_file('tests/unit/foo/bar/controller-test.js'))
           .to.contain("import { moduleFor, test } from 'ember-qunit';")
@@ -203,7 +203,7 @@ describe('Acceptance: ember generate and destroy controller', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/pods/foo/bar/controller.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain("export default Ember.Controller.extend({\n});");
+          .to.contain("export default Controller.extend({\n});");
 
         expect(_file('tests/unit/pods/foo/bar/controller-test.js'))
           .to.contain("import { moduleFor, test } from 'ember-qunit';")

--- a/node-tests/blueprints/helper-test.js
+++ b/node-tests/blueprints/helper-test.js
@@ -19,11 +19,11 @@ describe('Acceptance: ember generate and destroy helper', function() {
     return emberNew()
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/helpers/foo/bar-baz.js'))
-          .to.contain("import Ember from 'ember';\n\n" +
-                      "export function fooBarBaz(params/*, hash*/) {\n" +
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export function fooBarBaz(params/*, hash*/) {\n" +
                       "  return params;\n" +
                       "}\n\n" +
-                      "export default Ember.Helper.helper(fooBarBaz);");
+                      "export default Helper.helper(fooBarBaz);");
 
         expect(_file('tests/unit/helpers/foo/bar-baz-test.js'))
           .to.contain("import { fooBarBaz } from 'my-app/helpers/foo/bar-baz';");
@@ -36,11 +36,11 @@ describe('Acceptance: ember generate and destroy helper', function() {
     return emberNew({target: 'addon'})
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('addon/helpers/foo-bar.js'))
-          .to.contain("import Ember from 'ember';\n\n" +
-                      "export function fooBar(params/*, hash*/) {\n" +
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export function fooBar(params/*, hash*/) {\n" +
                       "  return params;\n" +
                       "}\n\n" +
-                      "export default Ember.Helper.helper(fooBar);");
+                      "export default Helper.helper(fooBar);");
 
         expect(_file('app/helpers/foo-bar.js'))
           .to.contain("export { default, fooBar } from 'my-addon/helpers/foo-bar';");
@@ -56,11 +56,11 @@ describe('Acceptance: ember generate and destroy helper', function() {
     return emberNew({target: 'addon'})
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('addon/helpers/foo/bar-baz.js'))
-          .to.contain("import Ember from 'ember';\n\n" +
-                      "export function fooBarBaz(params/*, hash*/) {\n" +
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export function fooBarBaz(params/*, hash*/) {\n" +
                       "  return params;\n" +
                       "}\n\n" +
-                      "export default Ember.Helper.helper(fooBarBaz);");
+                      "export default Helper.helper(fooBarBaz);");
 
         expect(_file('app/helpers/foo/bar-baz.js'))
           .to.contain("export { default, fooBarBaz } from 'my-addon/helpers/foo/bar-baz';");
@@ -76,11 +76,11 @@ describe('Acceptance: ember generate and destroy helper', function() {
     return emberNew({target: 'addon'})
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('tests/dummy/app/helpers/foo-bar.js'))
-          .to.contain("import Ember from 'ember';\n\n" +
-                      "export function fooBar(params/*, hash*/) {\n" +
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export function fooBar(params/*, hash*/) {\n" +
                       "  return params;\n" +
                       "}\n\n" +
-                      "export default Ember.Helper.helper(fooBar);");
+                      "export default Helper.helper(fooBar);");
 
         expect(_file('app/helpers/foo-bar.js'))
           .to.not.exist;
@@ -96,11 +96,11 @@ describe('Acceptance: ember generate and destroy helper', function() {
     return emberNew({target: 'addon'})
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('tests/dummy/app/helpers/foo/bar-baz.js'))
-          .to.contain("import Ember from 'ember';\n\n" +
-                      "export function fooBarBaz(params/*, hash*/) {\n" +
+          .to.contain("import Ember from 'ember'")
+          .to.contain("export function fooBarBaz(params/*, hash*/) {\n" +
                       "  return params;\n" +
                       "}\n\n" +
-                      "export default Ember.Helper.helper(fooBarBaz);");
+                      "export default Helper.helper(fooBarBaz);");
 
         expect(_file('app/helpers/foo/bar-baz.js'))
           .to.not.exist;
@@ -116,11 +116,11 @@ describe('Acceptance: ember generate and destroy helper', function() {
     return emberNew({target: 'in-repo-addon'})
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('lib/my-addon/addon/helpers/foo-bar.js'))
-          .to.contain("import Ember from 'ember';\n\n" +
-                      "export function fooBar(params/*, hash*/) {\n" +
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export function fooBar(params/*, hash*/) {\n" +
                       "  return params;\n" +
                       "}\n\n" +
-                      "export default Ember.Helper.helper(fooBar);");
+                      "export default Helper.helper(fooBar);");
 
         expect(_file('lib/my-addon/app/helpers/foo-bar.js'))
           .to.contain("export { default, fooBar } from 'my-addon/helpers/foo-bar';");
@@ -136,11 +136,11 @@ describe('Acceptance: ember generate and destroy helper', function() {
     return emberNew({target: 'in-repo-addon'})
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('lib/my-addon/addon/helpers/foo/bar-baz.js'))
-          .to.contain("import Ember from 'ember';\n\n" +
-                      "export function fooBarBaz(params/*, hash*/) {\n" +
+          .to.contain("import Ember from 'ember'")
+          .to.contain("export function fooBarBaz(params/*, hash*/) {\n" +
                       "  return params;\n" +
                       "}\n\n" +
-                      "export default Ember.Helper.helper(fooBarBaz);");
+                      "export default Helper.helper(fooBarBaz);");
 
         expect(_file('lib/my-addon/app/helpers/foo/bar-baz.js'))
           .to.contain("export { default, fooBarBaz } from 'my-addon/helpers/foo/bar-baz';");
@@ -156,11 +156,11 @@ describe('Acceptance: ember generate and destroy helper', function() {
     return emberNew()
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/helpers/foo-bar.js'))
-          .to.contain("import Ember from 'ember';\n\n" +
-                      "export function fooBar(params/*, hash*/) {\n" +
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export function fooBar(params/*, hash*/) {\n" +
                       "  return params;\n" +
                       "}\n\n" +
-                      "export default Ember.Helper.helper(fooBar);");
+                      "export default Helper.helper(fooBar);");
 
         expect(_file('tests/unit/helpers/foo-bar-test.js'))
           .to.contain("import { fooBar } from 'my-app/helpers/foo-bar';");
@@ -174,11 +174,11 @@ describe('Acceptance: ember generate and destroy helper', function() {
       .then(() => setupPodConfig({ podModulePrefix: true }))
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/helpers/foo-bar.js'))
-          .to.contain("import Ember from 'ember';\n\n" +
-                      "export function fooBar(params/*, hash*/) {\n" +
+          .to.contain("import Ember from 'ember'")
+          .to.contain("export function fooBar(params/*, hash*/) {\n" +
                       "  return params;\n" +
                       "}\n\n" +
-                      "export default Ember.Helper.helper(fooBar);");
+                      "export default Helper.helper(fooBar);");
 
         expect(_file('tests/unit/helpers/foo-bar-test.js'))
           .to.contain("import { fooBar } from 'my-app/helpers/foo-bar';");
@@ -191,11 +191,11 @@ describe('Acceptance: ember generate and destroy helper', function() {
     return emberNew()
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/helpers/foo/bar-baz.js'))
-          .to.contain("import Ember from 'ember';\n\n" +
-                      "export function fooBarBaz(params/*, hash*/) {\n" +
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export function fooBarBaz(params/*, hash*/) {\n" +
                       "  return params;\n" +
                       "}\n\n" +
-                      "export default Ember.Helper.helper(fooBarBaz);");
+                      "export default Helper.helper(fooBarBaz);");
 
         expect(_file('tests/unit/helpers/foo/bar-baz-test.js'))
           .to.contain("import { fooBarBaz } from 'my-app/helpers/foo/bar-baz';");
@@ -209,11 +209,11 @@ describe('Acceptance: ember generate and destroy helper', function() {
       .then(() => setupPodConfig({ podModulePrefix: true }))
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/helpers/foo/bar-baz.js'))
-          .to.contain("import Ember from 'ember';\n\n" +
-          "export function fooBarBaz(params/*, hash*/) {\n" +
+          .to.contain("import Ember from 'ember';")
+          .to.contain("export function fooBarBaz(params/*, hash*/) {\n" +
           "  return params;\n" +
           "}\n\n" +
-          "export default Ember.Helper.helper(fooBarBaz);");
+          "export default Helper.helper(fooBarBaz);");
 
         expect(_file('tests/unit/helpers/foo/bar-baz-test.js'))
           .to.contain("import { fooBarBaz } from 'my-app/helpers/foo/bar-baz';");

--- a/node-tests/blueprints/initializer-test.js
+++ b/node-tests/blueprints/initializer-test.js
@@ -237,7 +237,7 @@ describe('Acceptance: ember generate and destroy initializer', function() {
         expect(_file('tests/unit/initializers/foo-test.js'))
           .to.contain("import { initialize } from 'my-app/initializers/foo';")
           .to.contain("module('Unit | Initializer | foo'")
-          .to.contain("application = Ember.Application.create();")
+          .to.contain("application = Application.create();")
           .to.contain("initialize(this.application);");
       }));
   });
@@ -250,7 +250,7 @@ describe('Acceptance: ember generate and destroy initializer', function() {
         expect(_file('tests/unit/initializers/foo-test.js'))
           .to.contain("import { initialize } from 'dummy/initializers/foo';")
           .to.contain("module('Unit | Initializer | foo'")
-          .to.contain("application = Ember.Application.create();")
+          .to.contain("application = Application.create();")
           .to.contain("initialize(this.application);");
       }));
   });
@@ -267,7 +267,7 @@ describe('Acceptance: ember generate and destroy initializer', function() {
         expect(_file('tests/unit/initializers/foo-test.js'))
           .to.contain("import { initialize } from 'my-app/initializers/foo';")
           .to.contain("describe('Unit | Initializer | foo', function() {")
-          .to.contain("application = Ember.Application.create();")
+          .to.contain("application = Application.create();")
           .to.contain("initialize(application);");
       }));
   });

--- a/node-tests/blueprints/instance-initializer-test.js
+++ b/node-tests/blueprints/instance-initializer-test.js
@@ -231,7 +231,7 @@ describe('Acceptance: ember generate and destroy instance-initializer', function
         expect(_file('tests/unit/instance-initializers/foo-test.js'))
           .to.contain("import { initialize } from 'my-app/instance-initializers/foo';")
           .to.contain("module('Unit | Instance Initializer | foo'")
-          .to.contain("application = Ember.Application.create();")
+          .to.contain("application = Application.create();")
           .to.contain("this.appInstance = this.application.buildInstance();")
           .to.contain("initialize(this.appInstance);");
       }));
@@ -245,7 +245,7 @@ describe('Acceptance: ember generate and destroy instance-initializer', function
         expect(_file('tests/unit/instance-initializers/foo-test.js'))
           .to.contain("import { initialize } from 'dummy/instance-initializers/foo';")
           .to.contain("module('Unit | Instance Initializer | foo'")
-          .to.contain("application = Ember.Application.create();")
+          .to.contain("application = Application.create();")
           .to.contain("this.appInstance = this.application.buildInstance();")
           .to.contain("initialize(this.appInstance);");
       }));
@@ -263,7 +263,7 @@ describe('Acceptance: ember generate and destroy instance-initializer', function
         expect(_file('tests/unit/instance-initializers/foo-test.js'))
           .to.contain("import { initialize } from 'my-app/instance-initializers/foo';")
           .to.contain("describe('Unit | Instance Initializer | foo', function() {")
-          .to.contain("application = Ember.Application.create();")
+          .to.contain("application = Application.create();")
           .to.contain("appInstance = application.buildInstance();")
           .to.contain("initialize(appInstance);");
       }));

--- a/node-tests/blueprints/mixin-test.js
+++ b/node-tests/blueprints/mixin-test.js
@@ -20,7 +20,7 @@ describe('Acceptance: ember generate and destroy mixin', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/mixins/foo.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain('export default Ember.Mixin.create({\n});');
+          .to.contain('export default Mixin.create({\n});');
 
         expect(_file('tests/unit/mixins/foo-test.js'))
           .to.contain("import FooMixin from 'my-app/mixins/foo';");
@@ -34,7 +34,7 @@ describe('Acceptance: ember generate and destroy mixin', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/mixins/foo/bar.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain('export default Ember.Mixin.create({\n});');
+          .to.contain('export default Mixin.create({\n});');
 
         expect(_file('tests/unit/mixins/foo/bar-test.js'))
           .to.contain("import FooBarMixin from 'my-app/mixins/foo/bar';");
@@ -58,7 +58,7 @@ describe('Acceptance: ember generate and destroy mixin', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('addon/mixins/foo.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain('export default Ember.Mixin.create({\n});');
+          .to.contain('export default Mixin.create({\n});');
 
         expect(_file('tests/unit/mixins/foo-test.js'))
           .to.contain("import FooMixin from 'my-addon/mixins/foo';");
@@ -75,7 +75,7 @@ describe('Acceptance: ember generate and destroy mixin', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('addon/mixins/foo/bar.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain('export default Ember.Mixin.create({\n});');
+          .to.contain('export default Mixin.create({\n});');
 
         expect(_file('tests/unit/mixins/foo/bar-test.js'))
           .to.contain("import FooBarMixin from 'my-addon/mixins/foo/bar';");
@@ -92,7 +92,7 @@ describe('Acceptance: ember generate and destroy mixin', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('addon/mixins/foo/bar/baz.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain('export default Ember.Mixin.create({\n});');
+          .to.contain('export default Mixin.create({\n});');
 
         expect(_file('tests/unit/mixins/foo/bar/baz-test.js'))
           .to.contain("import FooBarBazMixin from 'my-addon/mixins/foo/bar/baz';");
@@ -109,7 +109,7 @@ describe('Acceptance: ember generate and destroy mixin', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('lib/my-addon/addon/mixins/foo.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain('export default Ember.Mixin.create({\n});');
+          .to.contain('export default Mixin.create({\n});');
 
         expect(_file('tests/unit/mixins/foo-test.js'))
           .to.contain("import FooMixin from 'my-addon/mixins/foo';");
@@ -123,7 +123,7 @@ describe('Acceptance: ember generate and destroy mixin', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('lib/my-addon/addon/mixins/foo/bar.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain('export default Ember.Mixin.create({\n});');
+          .to.contain('export default Mixin.create({\n});');
 
         expect(_file('tests/unit/mixins/foo/bar-test.js'))
           .to.contain("import FooBarMixin from 'my-addon/mixins/foo/bar';");
@@ -149,7 +149,7 @@ describe('Acceptance: ember generate and destroy mixin', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/mixins/foo.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain('export default Ember.Mixin.create({\n});');
+          .to.contain('export default Mixin.create({\n});');
 
         expect(_file('tests/unit/mixins/foo-test.js'))
           .to.contain("import FooMixin from 'my-app/mixins/foo';");
@@ -164,7 +164,7 @@ describe('Acceptance: ember generate and destroy mixin', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/mixins/foo.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain('export default Ember.Mixin.create({\n});');
+          .to.contain('export default Mixin.create({\n});');
 
         expect(_file('tests/unit/mixins/foo-test.js'))
           .to.contain("import FooMixin from 'my-app/mixins/foo';");
@@ -178,7 +178,7 @@ describe('Acceptance: ember generate and destroy mixin', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/mixins/foo/bar.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain('export default Ember.Mixin.create({\n});');
+          .to.contain('export default Mixin.create({\n});');
 
         expect(_file('tests/unit/mixins/foo/bar-test.js'))
           .to.contain("import FooBarMixin from 'my-app/mixins/foo/bar';");
@@ -193,7 +193,7 @@ describe('Acceptance: ember generate and destroy mixin', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/mixins/foo/bar.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain('export default Ember.Mixin.create({\n});');
+          .to.contain('export default Mixin.create({\n});');
 
         expect(_file('tests/unit/mixins/foo/bar-test.js'))
           .to.contain("import FooBarMixin from 'my-app/mixins/foo/bar';");

--- a/node-tests/blueprints/resource-test.js
+++ b/node-tests/blueprints/resource-test.js
@@ -19,7 +19,7 @@ describe('Acceptance: ember generate and destroy resource', function() {
       .then(() => emberGenerateDestroy(args, (_file) => {
         expect(_file('app/routes/foo.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain("export default Ember.Route.extend({\n});");
+          .to.contain("export default Route.extend({\n});");
 
         expect(_file('app/templates/foo.hbs'))
           .to.contain('{{outlet}}');

--- a/node-tests/blueprints/route-test.js
+++ b/node-tests/blueprints/route-test.js
@@ -30,7 +30,7 @@ describe('Acceptance: ember generate and destroy route', function() {
       .then(() => emberGenerateDestroy(args, (_file) => {
         expect(_file('app/routes/foo.js'))
           .to.contain('import Ember from \'ember\';')
-          .to.contain('export default Ember.Route.extend({\n});');
+          .to.contain('export default Route.extend({\n});');
 
         expect(_file('app/templates/foo.hbs'))
           .to.contain('{{outlet}}');
@@ -66,7 +66,7 @@ describe('Acceptance: ember generate and destroy route', function() {
       .then(() => emberGenerateDestroy(args, (_file) => {
         expect(_file('app/routes/foo.js'))
           .to.contain('import Ember from \'ember\';')
-          .to.contain('export default Ember.Route.extend({\n});');
+          .to.contain('export default Route.extend({\n});');
 
         expect(_file('app/templates/foo.hbs'))
           .to.contain('{{outlet}}');
@@ -125,7 +125,7 @@ describe('Acceptance: ember generate and destroy route', function() {
       .then(() => emberGenerateDestroy(args, (_file) => {
         expect(_file('addon/routes/foo.js'))
           .to.contain('import Ember from \'ember\';')
-          .to.contain('export default Ember.Route.extend({\n});');
+          .to.contain('export default Route.extend({\n});');
 
         expect(_file('addon/templates/foo.hbs'))
           .to.contain('{{outlet}}');
@@ -154,7 +154,7 @@ describe('Acceptance: ember generate and destroy route', function() {
       .then(() => emberGenerateDestroy(args, (_file) => {
         expect(_file('addon/routes/foo/bar.js'))
           .to.contain('import Ember from \'ember\';')
-          .to.contain('export default Ember.Route.extend({\n});');
+          .to.contain('export default Route.extend({\n});');
 
         expect(_file('addon/templates/foo/bar.hbs'))
           .to.contain('{{outlet}}');
@@ -183,7 +183,7 @@ describe('Acceptance: ember generate and destroy route', function() {
       .then(() => emberGenerateDestroy(args, (_file) => {
         expect(_file('tests/dummy/app/routes/foo.js'))
           .to.contain('import Ember from \'ember\';')
-          .to.contain('export default Ember.Route.extend({\n});');
+          .to.contain('export default Route.extend({\n});');
 
         expect(_file('tests/dummy/app/templates/foo.hbs'))
           .to.contain('{{outlet}}');
@@ -206,7 +206,7 @@ describe('Acceptance: ember generate and destroy route', function() {
       .then(() => emberGenerateDestroy(args, (_file) => {
         expect(_file('tests/dummy/app/routes/foo/bar.js'))
           .to.contain('import Ember from \'ember\';')
-          .to.contain('export default Ember.Route.extend({\n});');
+          .to.contain('export default Route.extend({\n});');
 
         expect(_file('tests/dummy/app/templates/foo/bar.hbs'))
           .to.contain('{{outlet}}');
@@ -230,7 +230,7 @@ describe('Acceptance: ember generate and destroy route', function() {
       .then(() => emberGenerateDestroy(args, (_file) => {
         expect(_file('lib/my-addon/addon/routes/foo.js'))
           .to.contain('import Ember from \'ember\';')
-          .to.contain('export default Ember.Route.extend({\n});');
+          .to.contain('export default Route.extend({\n});');
 
         expect(_file('lib/my-addon/addon/templates/foo.hbs'))
           .to.contain('{{outlet}}');
@@ -254,7 +254,7 @@ describe('Acceptance: ember generate and destroy route', function() {
       .then(() => emberGenerateDestroy(args, (_file) => {
         expect(_file('lib/my-addon/addon/routes/foo/bar.js'))
           .to.contain('import Ember from \'ember\';')
-          .to.contain('export default Ember.Route.extend({\n});');
+          .to.contain('export default Route.extend({\n});');
 
         expect(_file('lib/my-addon/addon/templates/foo/bar.hbs'))
           .to.contain('{{outlet}}');
@@ -278,7 +278,7 @@ describe('Acceptance: ember generate and destroy route', function() {
       .then(() => emberGenerateDestroy(args, (_file) => {
         expect(_file('app/foo/route.js'))
           .to.contain('import Ember from \'ember\';')
-          .to.contain('export default Ember.Route.extend({\n});');
+          .to.contain('export default Route.extend({\n});');
 
         expect(_file('app/foo/template.hbs'))
           .to.contain('{{outlet}}');
@@ -318,7 +318,7 @@ describe('Acceptance: ember generate and destroy route', function() {
       .then(() => emberGenerateDestroy(args, (_file) => {
         expect(_file('app/pods/foo/route.js'))
           .to.contain('import Ember from \'ember\';')
-          .to.contain('export default Ember.Route.extend({\n});');
+          .to.contain('export default Route.extend({\n});');
 
         expect(_file('app/pods/foo/template.hbs'))
           .to.contain('{{outlet}}');
@@ -372,7 +372,7 @@ describe('Acceptance: ember generate and destroy route', function() {
       .then(() => emberGenerateDestroy(args, (_file) => {
         expect(_file('addon/foo/route.js'))
           .to.contain('import Ember from \'ember\';')
-          .to.contain('export default Ember.Route.extend({\n});');
+          .to.contain('export default Route.extend({\n});');
 
         expect(_file('addon/foo/template.hbs'))
           .to.contain('{{outlet}}');

--- a/node-tests/blueprints/service-test.js
+++ b/node-tests/blueprints/service-test.js
@@ -22,7 +22,7 @@ describe('Acceptance: ember generate and destroy service', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/services/foo.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain('export default Ember.Service.extend({\n});');
+          .to.contain('export default Service.extend({\n});');
 
         expect(_file('tests/unit/services/foo-test.js'))
           .to.contain("import { moduleFor, test } from 'ember-qunit';")
@@ -37,7 +37,7 @@ describe('Acceptance: ember generate and destroy service', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/services/foo/bar.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain('export default Ember.Service.extend({\n});');
+          .to.contain('export default Service.extend({\n});');
 
         expect(_file('tests/unit/services/foo/bar-test.js'))
           .to.contain("import { moduleFor, test } from 'ember-qunit';")
@@ -51,7 +51,7 @@ describe('Acceptance: ember generate and destroy service', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('addon/services/foo.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain('export default Ember.Service.extend({\n});');
+          .to.contain('export default Service.extend({\n});');
 
         expect(_file('app/services/foo.js'))
           .to.contain("export { default } from 'my-addon/services/foo';");
@@ -69,7 +69,7 @@ describe('Acceptance: ember generate and destroy service', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('addon/services/foo/bar.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain('export default Ember.Service.extend({\n});');
+          .to.contain('export default Service.extend({\n});');
 
         expect(_file('app/services/foo/bar.js'))
           .to.contain("export { default } from 'my-addon/services/foo/bar';");
@@ -87,7 +87,7 @@ describe('Acceptance: ember generate and destroy service', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/foo/service.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain('export default Ember.Service.extend({\n});');
+          .to.contain('export default Service.extend({\n});');
 
         expect(_file('tests/unit/foo/service-test.js'))
           .to.contain("import { moduleFor, test } from 'ember-qunit';")
@@ -102,7 +102,7 @@ describe('Acceptance: ember generate and destroy service', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/foo/bar/service.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain('export default Ember.Service.extend({\n});');
+          .to.contain('export default Service.extend({\n});');
 
         expect(_file('tests/unit/foo/bar/service-test.js'))
           .to.contain("import { moduleFor, test } from 'ember-qunit';")
@@ -118,7 +118,7 @@ describe('Acceptance: ember generate and destroy service', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/pods/foo/service.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain('export default Ember.Service.extend({\n});');
+          .to.contain('export default Service.extend({\n});');
 
         expect(_file('tests/unit/pods/foo/service-test.js'))
           .to.contain("import { moduleFor, test } from 'ember-qunit';")
@@ -134,7 +134,7 @@ describe('Acceptance: ember generate and destroy service', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('app/pods/foo/bar/service.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain('export default Ember.Service.extend({\n});');
+          .to.contain('export default Service.extend({\n});');
 
         expect(_file('tests/unit/pods/foo/bar/service-test.js'))
           .to.contain("import { moduleFor, test } from 'ember-qunit';")

--- a/node-tests/blueprints/test-helper-test.js
+++ b/node-tests/blueprints/test-helper-test.js
@@ -18,7 +18,7 @@ describe('Acceptance: ember generate and destroy test-helper', function() {
       .then(() => emberGenerateDestroy(args, _file => {
         expect(_file('tests/helpers/foo.js'))
           .to.contain("import Ember from 'ember';")
-          .to.contain('export default Ember.Test.registerAsyncHelper(\'foo\', function(app) {\n\n}');
+          .to.contain('export default Test.registerAsyncHelper(\'foo\', function(app) {\n\n}');
       }));
   });
 });


### PR DESCRIPTION
Eliminate directly accessing properties of the Ember object in blueprints. When using ember-suave (https://github.com/DockYard/eslint-plugin-ember-suave/blob/master/docs/rules/no-direct-property-access.md) for linting, this results in files that immediately fail linting. Connected to https://github.com/emberjs/ember.js/pull/15398.