### PR TITLE
Bump `ember-cli-version-checker` version 🚀

### DIFF
--- a/blueprints/test-framework-detector.js
+++ b/blueprints/test-framework-detector.js
@@ -14,7 +14,11 @@ module.exports = function(blueprint) {
     if ('ember-cli-qunit' in dependencies) {
       type = 'qunit';
     } else if ('ember-cli-mocha' in dependencies) {
-      var checker = new VersionChecker({ project: this.project });
+      var addon = {
+        project: this.project,
+        root: this.project.root
+      };
+      var checker = new VersionChecker(addon);
       if (fs.existsSync(this.path + '/mocha-0.12-files') && checker.for('ember-cli-mocha', 'npm').satisfies('>=0.12.0')) {
         type = 'mocha-0.12';
       } else {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "ember-cli-string-utils": "^1.0.0",
     "ember-cli-test-info": "^1.0.0",
     "ember-cli-valid-component-name": "^1.0.0",
-    "ember-cli-version-checker": "^1.1.7",
+    "ember-cli-version-checker": "^2.1.0",
     "ember-router-generator": "^1.0.0",
     "exists-sync": "0.0.3",
     "fs-extra": "^0.24.0",


### PR DESCRIPTION
In order to fix deprecation messages as described in https://github.com/ember-cli/ember-cli/issues/7408, we need to update to the latest version of `ember-cli-version-checker`.

This change also fixes a bug in `test-framework-detector` where `root` property was never passed in. In `ember-cli-version-checker@2+`, we [stopped](https://github.com/ember-cli/ember-cli-version-checker/commit/f1e3ff2780439703824063ada57a74f1a4317749) falling back to `this.project.root` property.